### PR TITLE
Add neo_srvs dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ find_package(catkin REQUIRED
             dynamic_reconfigure
             roscpp
             tf
+            neo_srvs
             neo_msgs
             neo_common
         )
@@ -36,6 +37,7 @@ catkin_package(
         dynamic_reconfigure
         roscpp
 		tf
+        neo_srvs
 		neo_msgs
 		neo_common
 )

--- a/package.xml
+++ b/package.xml
@@ -17,12 +17,14 @@
     <build_depend>dynamic_reconfigure</build_depend>
     <build_depend>roscpp</build_depend>
     <build_depend>tf</build_depend>
+    <build_depend>neo_srvs</build_depend>
     <build_depend>neo_msgs</build_depend>
     <build_depend>neo_common</build_depend>
 
     <run_depend>dynamic_reconfigure</run_depend>
     <run_depend>roscpp</run_depend>
     <run_depend>tf</run_depend>
+    <run_depend>neo_srvs</run_depend>
     <run_depend>neo_msgs</run_depend>
     <run_depend>neo_common</run_depend>
 


### PR DESCRIPTION
Solve compilation error when compiling neo_srvs pkg and neo_kinematics_omnidrive togheter
by adding neo_srvs dependency in CMakeLists and package.xml of neo_kinematics_omnidrive.